### PR TITLE
French translation - Closes #39

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,85 @@
+{
+    "extensionName": {
+        "message": "Suppression des publicités et de la surveillance pour Facebook™",
+        "description": "Nom du module complémentaire."
+    },
+    "extensionDescription": {
+        "message": "Supprime les publicités et la surveillance des interactions des utilisateurs du site web Facebook™",
+        "description": "Description du module complémentaire."
+    },
+    "optsTitle": {
+        "message": "Options du module complémentaire Suppression des publicités et de la surveillance pour Facebook™",
+        "description": "Titre de la page des options"
+    },
+    "optsLegend": {
+        "message": "Options"
+    },
+    "optsReloadNotice": {
+        "message": "Les modifications entraîneront le rechargement automatique de tous les onglets Facebook après la fermeture de cette page",
+        "description": "Remarque sur la page des options concernant le rechargement de la page après avoir apporté des modifications"
+    },
+    "optsEnabled": {
+        "message": "Activé"
+    },
+    "optsFixLinks": {
+        "message": "Supprimer la surveillance des liens vers l'extérieur du site"
+    },
+    "optsInternal": {
+        "message": "Supprimez les valeurs pour contrer la surveillance des liens internes au site<em>(si quelque chose se casse, essayez de le désactiver d'abord)</em>"
+    },
+    "optsInlineVids": {
+        "message": "Vidéos en ligne sur mobile <em>(n'affecte que les mobiles; peut augmenter l'utilisation des données)</em>"
+    },
+    "optsPixeled": {
+        "message": "Masquer les articles sponsorisés <em>(comprend la plupart des \"publications suggérées\")</em>"
+    },
+    "optsSuggest": {
+        "message": "Masquer les suggestions en ligne <em>(par exemple: messages suggérés, personnes que vous connaissez peut-être)</em>"
+    },
+    "optsHideMethod": {
+        "message": "Méthode de dissimulation:"
+    },
+    "optsCollapse": {
+        "message": "Effondrement"
+    },
+    "optsRemove": {
+        "message": "Suppression"
+    },
+    "optsUseStyle": {
+        "message": "Ajouter la mise en page aux éléments modifiés"
+    },
+    "optsAdvanced": {
+        "message": "Options Avançées"
+    },
+    "optsStyleLabel": {
+        "message": "Feuille de Style CSS personnalisée à ajouter aux éléments modifiés:"
+    },
+    "optsStylePreview": {
+        "message": "Aperçu de la mise en page"
+    },
+    "optsUserRules": {
+        "message": "Sélection des feuilles de styles CSS personnalisées à masquer, une par ligne. <em>À DES FINS DE TEST UNIQUEMENT</em>"
+    },
+    "optsUserRulesHover": {
+        "message": "Si vous identifiez une nouvelle feuille de style CSS à sélectionner, veuillez la soumettre dans un message pour les programmeurs"
+    },
+    "optsPending": {
+        "message": "Activer les règles de dissimulation en attente ou non confirmées"
+    },
+    "optsPendingLink": {
+        "message": "Voir la liste ici"
+    },
+    "optsLogging": {
+        "message": "Afficher les messages de journalisation dans la console"
+    },
+    "optsRefresh": {
+        "message": "Actualiser les règles"
+    },
+    "optsRefreshHover": {
+        "message": "Une seule fois par $1 minute(s)",
+        "description": "Message de compte à rebours de la règle de raffraichissemnt"
+    },
+    "optsDefaults": {
+        "message": "Restaurations des paramètres par défaut"
+    }
+}


### PR DESCRIPTION
french translation from english messages.json

-----------------
Removes Ads and the user interaction tracking on Facebook™.
Modified elements can optionally have a custom CSS style applied to them so that cleaned items can be more easily identified.

**Translation in french:**
Supprime les publicités et la surveillance des interactions des utilisateurs sur Facebook ™.
Les éléments modifiés peuvent éventuellement avoir une feuille de style CSS personnalisé qui leur est appliquée afin que les éléments nettoyés puissent être plus facilement identifiés.

--------------------------------------------------
Please report bugs at https://github.com/mgziminsky/FacebookTrackingRemoval/issues

Removes Ads and the user interaction tracking from content on Facebook™.
Modified elements can optionally have a custom CSS style applied to them so that cleaned items can be more easily identified.

For links, the event listeners on the link and its parents are removed and/or disabled and a proper href is set.

For videos on mobile, all Facebook™ event-listeners and custom controls are removed, and the video is simplified into just the bare HTML5 video tag.

Explanation of permissions:
Access to facebook.com, messenger.com, and facebookcorewwwi.onion is needed for main functionality, in order to work on those pages.
Access to mgziminsky.gitlab.io, more specifically https:<n/>//mgziminsky.gitlab.io/FacebookTrackingRemoval/*, is used to download blocking rules only. No data is sent, and nothing is tracked by me.

Project is completely open source, so you are welcome, and encouraged, to check the code yourself before installing.


**Translation in french:**
Veuillez signaler les problèmes à https://github.com/mgziminsky/FacebookTrackingRemoval/issues

Supprime les publicités et la surveillance des interactions utilisateur sur Facebook ™.
Les éléments modifiés peuvent éventuellement avoir une feuille de style CSS personnalisée qui leur est appliquée afin que les éléments nettoyés puissent être plus facilement identifiés.

Pour les liens, les auditeurs d'événements sur le lien et ses parents sont supprimés et/ou désactivés et un href approprié est défini.
Pour les vidéos sur mobile, tous les auditeurs d'événements et contrôles personnalisés de Facebook ™ sont supprimés, et la vidéo est simplifiée en un simple tag vidéo HTML5.
Explication des autorisations:
L'accès à facebook.com, messenger.com et facebookcorewwwi.onion est nécessaire pour les fonctionnalités principales, afin d'appliquer des modifications sur ces pages.
L'accès à mgziminsky.gitlab.io, plus spécifiquement https:<n/>//mgziminsky.gitlab.io/FacebookTrackingRemoval/*, est utilisé pour télécharger uniquement les règles de blocage. Aucune donnée n'est envoyée, et rien n'est surveiller de ma part.

Le projet est complètement open source, vous êtes donc les bienvenus et encouragés à vérifier le code vous-même avant l'installation.